### PR TITLE
setup fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ PACKAGES = find_packages(exclude=['tests', 'tests.*', 'build'])
 
 REQUIRES = [
     # 'cec',
+    'typing'
 ]
 
 setup(
@@ -34,7 +35,7 @@ setup(
     ],
     entry_points={
         'console_scripts': [
-            'pycec=pycec:main',
+            'pycec=pycec.__main__:main',
         ],
     },
 )


### PR DESCRIPTION
* Must install `typing` for <= py3.4
* entry point in `__main__`, not `__init__`