### PR TITLE
Require typing only for Python < 3.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-typing
+typing;python_version<"3.5"

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ PACKAGES = find_packages(exclude=['tests', 'tests.*', 'build'])
 
 REQUIRES = [
     # 'cec',
-    'typing'
+    'typing;python_version<"3.5"'
 ]
 
 setup(

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,1 +1,1 @@
-typing
+typing;python_version<"3.5"


### PR DESCRIPTION
It's included in later.