### PR TITLE
Various fixes to allow TcpAdapter to recover form a lost connection

### DIFF
--- a/pycec/tcp.py
+++ b/pycec/tcp.py
@@ -135,8 +135,8 @@ class TcpProtocol(asyncio.Protocol):
         self._adapter.shutdown()
 
     def connection_lost(self, exc):
-        self._adapter.shutdown()
         _LOGGER.warning("Connection lost. Trying to reconnect...")
+        self._initialized = False
         self._adapter._tcp_loop.stop()
         self._adapter.init()
 

--- a/pycec/tcp.py
+++ b/pycec/tcp.py
@@ -45,7 +45,7 @@ class TcpAdapter(AbstractCecAdapter):
                                                      port=self._port))
                 _LOGGER.debug("Connection started.")
                 break
-            except ConnectionRefusedError as e:
+            except (ConnectionRefusedError, RuntimeError) as e:
                 _LOGGER.warning(
                     "Unable to connect due to %s. Trying again in %d seconds, "
                     "%d attempts remaining.",

--- a/pycec/tcp.py
+++ b/pycec/tcp.py
@@ -32,9 +32,9 @@ class TcpAdapter(AbstractCecAdapter):
         if self._transport:
             _LOGGER.debug("New client: %s", self._transport)
             self._initialized = True
-            if callback:
-                callback()
             self._tcp_loop.run_in_executor(None, self._tcp_loop.run_forever)
+        if callback:
+            callback()
 
     def _init(self):
         for i in range(0, MAX_CONNECTION_ATTEMPTS):
@@ -143,7 +143,7 @@ class TcpProtocol(asyncio.Protocol):
 
 def main():
     """For testing purpose"""
-    tcp_adapter = TcpAdapter("192.168.1.3", name="HASS", activate_source=False)
+    tcp_adapter = TcpAdapter("192.168.1.5", name="HASS", activate_source=False)
     hdmi_network = HDMINetwork(tcp_adapter)
     hdmi_network.start()
     while True:

--- a/pycec/tcp.py
+++ b/pycec/tcp.py
@@ -63,8 +63,9 @@ class TcpAdapter(AbstractCecAdapter):
 
     def shutdown(self):
         self._initialized = False
-        if self._transport:
+        if self._transport and not self._transport.is_closing():
             self._transport.close()
+        self._transport = None
 
     def _poll_device(self, device):
         req = self._loop.time()
@@ -136,8 +137,7 @@ class TcpProtocol(asyncio.Protocol):
 
     def connection_lost(self, exc):
         _LOGGER.warning("Connection lost. Trying to reconnect...")
-        self._initialized = False
-        self._adapter.set_transport = None
+        self._adapter.shutdown()
         self._adapter._tcp_loop.stop()
         self._adapter.init()
 

--- a/pycec/tcp.py
+++ b/pycec/tcp.py
@@ -29,11 +29,12 @@ class TcpAdapter(AbstractCecAdapter):
         self._activate_source = activate_source
 
     def _after_init(self, callback, f):
-        _LOGGER.debug("New client: %s", self._transport)
-        self._initialized = True
-        if callback:
-            callback()
-        self._tcp_loop.run_in_executor(None, self._tcp_loop.run_forever)
+        if self._transport:
+            _LOGGER.debug("New client: %s", self._transport)
+            self._initialized = True
+            if callback:
+                callback()
+            self._tcp_loop.run_in_executor(None, self._tcp_loop.run_forever)
 
     def _init(self):
         for i in range(0, MAX_CONNECTION_ATTEMPTS):

--- a/pycec/tcp.py
+++ b/pycec/tcp.py
@@ -78,7 +78,7 @@ class TcpAdapter(AbstractCecAdapter):
                 return True
             if self._loop.time() > (req + 5):
                 return False
-            asyncio.sleep(.1, loop=self._loop)
+            time.sleep(.1)
 
     def poll_device(self, device):
         return self._loop.run_in_executor(None, self._poll_device, device)

--- a/pycec/tcp.py
+++ b/pycec/tcp.py
@@ -137,6 +137,7 @@ class TcpProtocol(asyncio.Protocol):
     def connection_lost(self, exc):
         _LOGGER.warning("Connection lost. Trying to reconnect...")
         self._initialized = False
+        self._adapter.set_transport = None
         self._adapter._tcp_loop.stop()
         self._adapter.init()
 


### PR DESCRIPTION
Callback `TcpAdapter._after_init` gets called regardless of whether `TcpAdapter._init` was successful. Only mark `TcpAdapter` initialized and start `TcpProtocol` if it was successful.

This and the other small fixes below will allow a TcpAdapter to recover from disconnection. 

Combined with this PR to Home Assistant, HA will automatically handle a disconnected TcpAdapter, first by marking the devices unavailable and then by attempting to reconnect. https://github.com/home-assistant/core/pull/38283

fixes #43 
fixes #55