### PR TITLE
Increment version number for release.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,26 @@ Change Log
 *************
 Added
 =====
+
+Changed
+=======
+
+Deprecated
+==========
+
+Removed
+=======
+
+Fixed
+=====
+
+Security
+========
+
+`0.5.0`_ 2020-10-04
+*******************
+Added
+=====
 - Added a changelog.
 - Added Python 3.8 testing.
 
@@ -12,9 +32,6 @@ Changed
 =======
 - Updated PyPi classifiers.
 - Updated asyncio syntax to use ``await`` and ``async def``.
-
-Deprecated
-==========
 
 Removed
 =======
@@ -26,14 +43,12 @@ Fixed
 - Added a missing ``await`` for an ``asyncio.sleep``.
 - Fixed long_description field for PyPi releases, the README will now render.
 
-Security
-========
-
 `0.4.14`_ 2020-09-27
 ********************
 Changed
 =======
 - Removed `typing` requirement.
 
-.. _Unreleased: https://github.com/konikvranik/pyCEC/compare/v0.4.14..HEAD
+.. _Unreleased: https://github.com/konikvranik/pyCEC/compare/v0.5.0..HEAD
+.. _0.5.0: https://github.com/konikvranik/pyCEC/releases/tag/v0.5.0
 .. _0.4.14: https://github.com/konikvranik/pyCEC/releases/tag/v0.4.14

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ PACKAGES = find_packages(exclude=["tests", "tests.*", "build"])
 
 setup(
     name="pyCEC",
-    version="0.4.14",
+    version="0.5.0",
     author="Petr Vraník",
     author_email="hpa@suteren.net",
     description=(


### PR DESCRIPTION
I chose to increment the minor version since this release drops Python 3.4 support which is a breaking change.

Related: #62 