### PR TITLE
Drop support for Python 3.5, add support for Python 3.9.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python ${{ matrix.python-version }}
@@ -25,7 +25,7 @@ jobs:
         run: coveralls
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_FLAG_NAME: ${{ matrix.test-name }}-${{ matrix.python-version }}
+          COVERALLS_FLAG_NAME: ${{ matrix.python-version }}
           COVERALLS_PARALLEL: true
       - name: Test Build
         run: python setup.py sdist
@@ -34,10 +34,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Python 3.8
+      - name: Setup Python 3.9
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Change Log
 *************
 Added
 =====
+- Added Python 3.9 support.
 
 Changed
 =======
@@ -14,6 +15,7 @@ Deprecated
 
 Removed
 =======
+- Drop Python 3.5 support (EOL).
 
 Fixed
 =====

--- a/setup.py
+++ b/setup.py
@@ -33,10 +33,10 @@ setup(
         "Topic :: Multimedia",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
Python 3.5 is now EOL, and now python 3.9 is the latest and greatest.

This will require changes in the github project settings @konikvranik, since this removes github actions for python 3.5 which is currently required.