### PR TITLE
Small fixes

### DIFF
--- a/pycec/cec.py
+++ b/pycec/cec.py
@@ -87,4 +87,4 @@ class CecAdapter(AbstractCecAdapter):
             else:
                 _LOGGER.error("failed to open a connection to the CEC adapter")
         if callback:
-            callback(self)
+            callback()

--- a/pycec/cec.py
+++ b/pycec/cec.py
@@ -41,7 +41,8 @@ class CecAdapter(AbstractCecAdapter):
 
     def shutdown(self):
         self._io_executor.shutdown()
-        self._adapter.Close()
+        if self._adapter:
+            self._adapter.Close()
 
     def get_logical_address(self):
         return self._adapter.GetLogicalAddresses().primary


### PR DESCRIPTION
I'm debugging a bug in [Home Assistant](https://github.com/home-assistant/core/issues/50443) and noted there were some errors generated in pycec. This happened because the adapter wasn't initialized due to an issue in docker. This mean that Close would be called on a none object.

The second bug relates to the use of the callback function. In HA, the [expectation](https://github.com/home-assistant/core/blob/dev/homeassistant/components/hdmi_cec/__init__.py#L225) is the callback doesn't require any additional args. I realize this is old code, but it does seem that the self in the callback is redundant.