### PR TITLE
Fix issues related to updating to Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python ${{ matrix.python-version }}

--- a/pycec/__main__.py
+++ b/pycec/__main__.py
@@ -16,7 +16,7 @@ async def async_show_devices(network, loop):
     while True:
         for d in network.devices:
             _LOGGER.debug("Present device %s", d)
-        await asyncio.sleep(10, loop=loop)
+        await asyncio.sleep(10)
 
 
 def main():

--- a/pycec/network.py
+++ b/pycec/network.py
@@ -248,7 +248,7 @@ class HDMIDevice:
             while not self._stop and self._loop.time() <= (
                 start_time + self._update_period
             ):
-                await asyncio.sleep(0.3, loop=self._loop)
+                await asyncio.sleep(0.3)
         _LOGGER.info("HDMI device %s stopped.", self)  # pragma: no cover
 
     def stop(self):  # pragma: no cover
@@ -329,7 +329,7 @@ class HDMINetwork:
         self._running = True
         while not (task.done() or task.cancelled()) and self._running:
             _LOGGER.debug("Init pending - %s", task)  # pragma: no cover
-            await asyncio.sleep(1, loop=self._loop)
+            await asyncio.sleep(1)
         _LOGGER.debug("Init done")  # pragma: no cover
 
     def scan(self):
@@ -417,10 +417,10 @@ class HDMINetwork:
                     self._loop.time() <= (start_time + self._scan_interval)
                     and self._running
                 ):
-                    await asyncio.sleep(0.3, loop=loop)
+                    await asyncio.sleep(0.3)
             else:
                 _LOGGER.warning("Not initialized. Waiting for init.")
-                await asyncio.sleep(1, loop=loop)
+                await asyncio.sleep(1)
         _LOGGER.info("No watching anymore")
 
     def start(self):

--- a/setup.py
+++ b/setup.py
@@ -33,10 +33,10 @@ setup(
         "Topic :: Multimedia",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     entry_points={
         "console_scripts": [

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,2 +1,2 @@
-pytest==6.1.0
-pytest-cov==2.10.1
+pytest==7.1.2
+pytest-cov==3.0.0

--- a/tests/test_hdmi_network.py
+++ b/tests/test_hdmi_network.py
@@ -41,7 +41,7 @@ def test_devices():
     # network._adapter.set_command_callback(network.command_callback)
     network.init()
     network.scan()
-    loop.run_until_complete(asyncio.sleep(0.1, loop))
+    loop.run_until_complete(asyncio.sleep(0.1))
     loop.stop()
     loop.run_forever()
     for i in [0, 1, 3, 5]:
@@ -85,7 +85,7 @@ def test_scan():
     # network._adapter.set_command_callback(network.command_callback)
     network.init()
     network.scan()
-    loop.run_until_complete(asyncio.sleep(0.1, loop))
+    loop.run_until_complete(asyncio.sleep(0.1))
     loop.stop()
     loop.run_forever()
 


### PR DESCRIPTION
Home Assistant has moved to Python 3.10. Currently the HDMI CEC integration fails to load: https://github.com/home-assistant/core/issues/74430. This fixes the issue and adds tests for Python 3.10.