### PR TITLE
Bump version to 0.6.0 and update changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,17 @@
 Change Log
 ##########
 
+`0.6.0`_ 2024-01-27
+*************
+Added
+=====
+- Publicly expose mute and volume status
+- New vendor ID mapping for Vizio
+
+Changed
+=======
+- Base Docker image on balenalib instead of resin
+
 `0.5.2`_ 2022-07-08
 *************
 Added

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ PACKAGES = find_packages(exclude=["tests", "tests.*", "build"])
 
 setup(
     name="pyCEC",
-    version="0.5.2",
+    version="0.6.0",
     author="Petr Vraník",
     author_email="hpa@suteren.net",
     description=(


### PR DESCRIPTION
I know the date'll be wrong on the changelog (since I have no control over when the release gets tagged). I figured it shouldn't be a big deal.

After merging this, would you kindly tag a new release?